### PR TITLE
Strip outputs of notebooks before uploading the project

### DIFF
--- a/treebeard-lib/Pipfile
+++ b/treebeard-lib/Pipfile
@@ -8,7 +8,7 @@ pylint = "*"
 autopep8 = "*"
 pipenv = "*"
 pytest = "*"
-python-magic-bin = "*"
+python-magic = "*"
 
 [packages]
 treebeard = {editable = true,path = "."}

--- a/treebeard-lib/Pipfile
+++ b/treebeard-lib/Pipfile
@@ -8,6 +8,7 @@ pylint = "*"
 autopep8 = "*"
 pipenv = "*"
 pytest = "*"
+python-magic-bin = "*"
 
 [packages]
 treebeard = {editable = true,path = "."}

--- a/treebeard-lib/Pipfile.lock
+++ b/treebeard-lib/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b800390ddce9da114c2157e31dbd353ba2d64ba45b9380b3e6be6c94ec2599d1"
+            "sha256": "522297b57b6d420b99c9b104ded7f96fa2c1db7e1293dc1e3276848c89eb2472"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -826,15 +826,6 @@
             ],
             "index": "pypi",
             "version": "==5.4.1"
-        },
-        "python-magic-bin": {
-            "hashes": [
-                "sha256:34a788c03adde7608028203e2dbb208f1f62225ad91518787ae26d603ae68892",
-                "sha256:7b1743b3dbf16601d6eedf4e7c2c9a637901b0faaf24ad4df4d4527e7d8f66a4",
-                "sha256:90be6206ad31071a36065a2fc169c5afb5e0355cbe6030e87641c6c62edc2b69"
-            ],
-            "index": "pypi",
-            "version": "==0.4.14"
         },
         "six": {
             "hashes": [

--- a/treebeard-lib/Pipfile.lock
+++ b/treebeard-lib/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "522297b57b6d420b99c9b104ded7f96fa2c1db7e1293dc1e3276848c89eb2472"
+            "sha256": "d528871493a140be9162e27fb06c57cafd6e8f03c496095ac9a396b73391a5aa"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -35,7 +35,7 @@
                 "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
                 "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
             ],
-            "markers": "platform_system == 'Darwin'",
+            "markers": "sys_platform == 'darwin'",
             "version": "==0.1.0"
         },
         "async-generator": {
@@ -826,6 +826,13 @@
             ],
             "index": "pypi",
             "version": "==5.4.1"
+        },
+        "python-magic": {
+            "hashes": [
+                "sha256:f2674dcfad52ae6c49d4803fa027809540b130db1dec928cfbb9240316831375",
+                "sha256:f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5"
+            ],
+            "version": "==0.4.15"
         },
         "six": {
             "hashes": [

--- a/treebeard-lib/Pipfile.lock
+++ b/treebeard-lib/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "522297b57b6d420b99c9b104ded7f96fa2c1db7e1293dc1e3276848c89eb2472"
+            "sha256": "980d25d0bcbdf569dee1c483a1b6a43cbd768fb441fe7c9b638a4779d89dfe0e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -401,6 +401,15 @@
             ],
             "version": "==0.4.15"
         },
+        "python-magic-bin": {
+            "hashes": [
+                "sha256:34a788c03adde7608028203e2dbb208f1f62225ad91518787ae26d603ae68892",
+                "sha256:7b1743b3dbf16601d6eedf4e7c2c9a637901b0faaf24ad4df4d4527e7d8f66a4",
+                "sha256:90be6206ad31071a36065a2fc169c5afb5e0355cbe6030e87641c6c62edc2b69"
+            ],
+            "index": "pypi",
+            "version": "==0.4.14"
+        },
         "pyyaml": {
             "hashes": [
                 "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
@@ -592,10 +601,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:03d2366c64d44c7f61e74c700d9b202d57e9efe355ea5c28814c52bfe7a50b8c",
-                "sha256:be5ddeec77d78ba781ea41eacb2358a77f74cc2407f54b82222d7ee7dc8c8ccf"
+                "sha256:00339634a22c10a7a22476ee946bbde2dbe48d042ded784e4d88e0236eca5d81",
+                "sha256:ea9e3fd6bd9a37e8783d75bfc4c1faf3c6813da6bd1c3e776488b41ec683af94"
             ],
-            "version": "==4.44.1"
+            "version": "==4.45.0"
         },
         "traitlets": {
             "hashes": [

--- a/treebeard-lib/Pipfile.lock
+++ b/treebeard-lib/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "980d25d0bcbdf569dee1c483a1b6a43cbd768fb441fe7c9b638a4779d89dfe0e"
+            "sha256": "b800390ddce9da114c2157e31dbd353ba2d64ba45b9380b3e6be6c94ec2599d1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -400,15 +400,6 @@
                 "sha256:f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5"
             ],
             "version": "==0.4.15"
-        },
-        "python-magic-bin": {
-            "hashes": [
-                "sha256:34a788c03adde7608028203e2dbb208f1f62225ad91518787ae26d603ae68892",
-                "sha256:7b1743b3dbf16601d6eedf4e7c2c9a637901b0faaf24ad4df4d4527e7d8f66a4",
-                "sha256:90be6206ad31071a36065a2fc169c5afb5e0355cbe6030e87641c6c62edc2b69"
-            ],
-            "index": "pypi",
-            "version": "==0.4.14"
         },
         "pyyaml": {
             "hashes": [
@@ -835,6 +826,15 @@
             ],
             "index": "pypi",
             "version": "==5.4.1"
+        },
+        "python-magic-bin": {
+            "hashes": [
+                "sha256:34a788c03adde7608028203e2dbb208f1f62225ad91518787ae26d603ae68892",
+                "sha256:7b1743b3dbf16601d6eedf4e7c2c9a637901b0faaf24ad4df4d4527e7d8f66a4",
+                "sha256:90be6206ad31071a36065a2fc169c5afb5e0355cbe6030e87641c6c62edc2b69"
+            ],
+            "index": "pypi",
+            "version": "==0.4.14"
         },
         "six": {
             "hashes": [

--- a/treebeard-lib/treebeard/buildtime/run_repo.py
+++ b/treebeard-lib/treebeard/buildtime/run_repo.py
@@ -1,6 +1,5 @@
 import os
 import subprocess
-from glob import glob
 from pathlib import Path
 from traceback import format_exc
 from typing import Any, Optional

--- a/treebeard-lib/treebeard/buildtime/run_repo.py
+++ b/treebeard-lib/treebeard/buildtime/run_repo.py
@@ -54,7 +54,7 @@ def run_repo(
                 abs_notebook_dir, f"/tmp/{notebook_id}_secrets.tgz", secrets_url
             )
 
-        subprocess.check_output(["nbstripout"] + glob("./*.ipynb"))
+        subprocess.check_output(["nbstripout"] + glob(".**/*.ipynb"))
     finally:
         click.echo("Treebeard Bundle Contents:")
         subprocess.run(["pwd"])

--- a/treebeard-lib/treebeard/buildtime/run_repo.py
+++ b/treebeard-lib/treebeard/buildtime/run_repo.py
@@ -10,7 +10,7 @@ import docker  # type: ignore
 from docker.errors import ImageNotFound  # type: ignore
 
 from treebeard.buildtime.helper import run_image
-from treebeard.conf import run_path, treebeard_env
+from treebeard.conf import run_path, treebeard_config, treebeard_env
 from treebeard.helper import sanitise_notebook_id
 from treebeard.util import fatal_exit
 
@@ -54,7 +54,7 @@ def run_repo(
                 abs_notebook_dir, f"/tmp/{notebook_id}_secrets.tgz", secrets_url
             )
 
-        subprocess.check_output(["nbstripout"] + glob(".**/*.ipynb"))
+        subprocess.check_output(["nbstripout"] + treebeard_config.deglobbed_notebooks)
     finally:
         click.echo("Treebeard Bundle Contents:")
         subprocess.run(["pwd"])

--- a/treebeard-lib/treebeard/notebooks/commands.py
+++ b/treebeard-lib/treebeard/notebooks/commands.py
@@ -22,9 +22,14 @@ from halo import Halo  # type: ignore
 from humanfriendly import format_size, parse_size  # type: ignore
 from timeago import format as timeago_format  # type: ignore
 from treebeard.buildtime.run_repo import run_repo
-from treebeard.conf import (config_path, get_time, notebooks_endpoint,
-                            treebeard_config, treebeard_env,
-                            validate_notebook_directory)
+from treebeard.conf import (
+    config_path,
+    get_time,
+    notebooks_endpoint,
+    treebeard_config,
+    treebeard_env,
+    validate_notebook_directory,
+)
 from treebeard.helper import CliContext, sanitise_notebook_id
 from treebeard.notebooks.types import Run
 from treebeard.secrets.commands import push_secrets
@@ -104,7 +109,7 @@ def run(
     temp_dir = tempfile.mkdtemp()
     copy_tree(os.getcwd(), temp_dir)
 
-    subprocess.check_output(["nbstripout"] + glob(".**/*.ipynb"), cwd=temp_dir)
+    subprocess.check_output(["nbstripout"] + glob.glob(".**/*.ipynb"), cwd=temp_dir)
 
     click.echo("🌲  Compressing Repo")
 
@@ -123,9 +128,7 @@ def run(
                 click.echo(f"  Including {info.name}")
                 return info
 
-            tar.add(
-                temp_dir, arcname=os.path.basename(os.path.sep), filter=zip_filter
-            )
+            tar.add(temp_dir, arcname=os.path.basename(os.path.sep), filter=zip_filter)
             tar.add(config_path, arcname=os.path.basename(config_path))
 
     if not (

--- a/treebeard-lib/treebeard/notebooks/commands.py
+++ b/treebeard-lib/treebeard/notebooks/commands.py
@@ -6,11 +6,10 @@ import pprint
 import subprocess
 import sys
 import tarfile
-import tempfile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 import time
 from datetime import datetime
 from distutils.dir_util import copy_tree
-from glob import glob
 from traceback import format_exc
 from typing import Any, List
 
@@ -106,81 +105,83 @@ def run(
     click.echo("🌲  Copying project and stripping notebooks")
 
     # copying project to temp dir to strip notebooks
-    temp_dir = tempfile.mkdtemp()
-    copy_tree(os.getcwd(), temp_dir)
+    with TemporaryDirectory() as temp_dir:
+        copy_tree(os.getcwd(), str(temp_dir))
+        subprocess.check_output(["nbstripout"] + glob.glob(".**/*.ipynb"), cwd=temp_dir)
 
-    subprocess.check_output(["nbstripout"] + glob.glob(".**/*.ipynb"), cwd=temp_dir)
+        click.echo("🌲  Compressing Repo")
 
-    click.echo("🌲  Compressing Repo")
+        with NamedTemporaryFile("wb", suffix=".tar.gz", delete=False) as src_archive:
+            with tarfile.open(fileobj=src_archive, mode="w:gz") as tar:
 
-    with tempfile.NamedTemporaryFile(
-        "wb", suffix=".tar.gz", delete=False
-    ) as src_archive:
-        with tarfile.open(fileobj=src_archive, mode="w:gz") as tar:
+                def zip_filter(info: tarfile.TarInfo):
+                    for ignored in ignore:
+                        if info.name in glob.glob(ignored, recursive=True):
+                            return None
 
-            def zip_filter(info: tarfile.TarInfo):
-                for ignored in ignore:
-                    if info.name in glob.glob(ignored, recursive=True):
-                        return None
+                    # if len(git_files) > 0 and info.name not in git_files:
+                    #     return None
+                    click.echo(f"  Including {info.name}")
+                    return info
 
-                # if len(git_files) > 0 and info.name not in git_files:
-                #     return None
-                click.echo(f"  Including {info.name}")
-                return info
+                tar.add(
+                    str(temp_dir),
+                    arcname=os.path.basename(os.path.sep),
+                    filter=zip_filter,
+                )
+                tar.add(config_path, arcname=os.path.basename(config_path))
 
-            tar.add(temp_dir, arcname=os.path.basename(os.path.sep), filter=zip_filter)
-            tar.add(config_path, arcname=os.path.basename(config_path))
+        if not (
+            confirm
+            or confirm_no_secrets
+            or click.confirm("Confirm source file set is correct?", default=True)
+        ):
+            click.echo("Exiting")
+            sys.exit()
 
-    if not (
-        confirm
-        or confirm_no_secrets
-        or click.confirm("Confirm source file set is correct?", default=True)
-    ):
-        click.echo("Exiting")
-        sys.exit()
-
-    size = os.path.getsize(src_archive.name)
-    max_upload_size = "100MB"
-    if size > parse_size(max_upload_size):
-        fatal_exit(
-            click.style(
-                (
-                    f"ERROR: Compressed notebook directory is {format_size(size)},"
-                    f" max upload size is {max_upload_size}. \nPlease ensure you ignore any virtualenv subdirectory"
-                    " using `treebeard run --ignore venv`"
-                ),
-                fg="red",
+        size = os.path.getsize(src_archive.name)
+        max_upload_size = "100MB"
+        if size > parse_size(max_upload_size):
+            fatal_exit(
+                click.style(
+                    (
+                        f"ERROR: Compressed notebook directory is {format_size(size)},"
+                        f" max upload size is {max_upload_size}. \nPlease ensure you ignore any virtualenv subdirectory"
+                        " using `treebeard run --ignore venv`"
+                    ),
+                    fg="red",
+                )
             )
+        if local:
+            build_tag = str(time.mktime(datetime.today().timetuple()))
+            repo_image_name = f"gcr.io/treebeard-259315/projects/{project_id}/{sanitise_notebook_id(str(notebook_id))}:{build_tag}"
+            click.echo(f"🌲  Building {repo_image_name} Locally\n")
+            secrets_archive = get_secrets_archive()
+            repo_url = f"file://{src_archive.name}"
+            secrets_url = f"file://{secrets_archive.name}"
+            try:
+                run_repo(
+                    str(project_id),
+                    str(notebook_id),
+                    treebeard_env.run_id,
+                    build_tag,
+                    repo_url,
+                    secrets_url,
+                    local=True,
+                )
+            except Exception:
+                click.echo(f"Failed to build...\n{format_exc()}")
+            finally:
+                sys.exit(0)
+
+        click.echo(f"🌲  submitting archive to runner ({format_size(size)})...")
+        response = requests.post(
+            notebooks_endpoint,
+            files={"repo": open(src_archive.name, "rb")},
+            params=params,
+            headers=treebeard_env.dict(),
         )
-    if local:
-        build_tag = str(time.mktime(datetime.today().timetuple()))
-        repo_image_name = f"gcr.io/treebeard-259315/projects/{project_id}/{sanitise_notebook_id(str(notebook_id))}:{build_tag}"
-        click.echo(f"🌲  Building {repo_image_name} Locally\n")
-        secrets_archive = get_secrets_archive()
-        repo_url = f"file://{src_archive.name}"
-        secrets_url = f"file://{secrets_archive.name}"
-        try:
-            run_repo(
-                str(project_id),
-                str(notebook_id),
-                treebeard_env.run_id,
-                build_tag,
-                repo_url,
-                secrets_url,
-                local=True,
-            )
-        except Exception:
-            click.echo(f"Failed to build...\n{format_exc()}")
-        finally:
-            sys.exit(0)
-
-    click.echo(f"🌲  submitting archive to runner ({format_size(size)})...")
-    response = requests.post(
-        notebooks_endpoint,
-        files={"repo": open(src_archive.name, "rb")},
-        params=params,
-        headers=treebeard_env.dict(),
-    )
+    # temp_dir cleaned up
 
     if response.status_code != 200:
         raise click.ClickException(f"Request failed: {response.text}")

--- a/treebeard-lib/treebeard/notebooks/commands.py
+++ b/treebeard-lib/treebeard/notebooks/commands.py
@@ -107,7 +107,7 @@ def run(
     # copying project to temp dir to strip notebooks
     with TemporaryDirectory() as temp_dir:
         copy_tree(os.getcwd(), str(temp_dir))
-        subprocess.check_output(["nbstripout"] + glob.glob(".**/*.ipynb"), cwd=temp_dir)
+        subprocess.check_output(["nbstripout"] + glob.glob("**/*.ipynb"), cwd=temp_dir)
 
         click.echo("🌲  Compressing Repo")
 

--- a/treebeard-lib/treebeard/notebooks/commands.py
+++ b/treebeard-lib/treebeard/notebooks/commands.py
@@ -107,8 +107,10 @@ def run(
     # copying project to temp dir to strip notebooks
     with TemporaryDirectory() as temp_dir:
         copy_tree(os.getcwd(), str(temp_dir))
-        subprocess.check_output(["nbstripout"] + glob.glob("**/*.ipynb"), cwd=temp_dir)
-
+        subprocess.check_output(
+            ["nbstripout"] + treebeard_config.deglobbed_notebooks, cwd=temp_dir
+        )
+        click.echo(treebeard_config.deglobbed_notebooks)
         click.echo("🌲  Compressing Repo")
 
         with NamedTemporaryFile("wb", suffix=".tar.gz", delete=False) as src_archive:


### PR DESCRIPTION
Don't want to strip users notebooks locally. 
So project directory is copied to a temporary directory,
nbstripout is called to strip cell outputs
then the copied directory is compressed and submitted to treebeard
temp dir is then cleaned up automatically
