### PR TITLE
Implements default behaviour of no treebeard.yaml file is found

### DIFF
--- a/treebeard-lib/treebeard/conf.py
+++ b/treebeard-lib/treebeard/conf.py
@@ -85,9 +85,11 @@ def validate_notebook_directory(
         fatal_exit("No account config detected! Please run `treebeard configure`")
 
     if not Path("treebeard.yaml").is_file():
-        fatal_exit(
-            "treebeard.yaml file not found! `treebeard setup` fetches an example."
+        click.secho(
+            "Warning: treebeard.yaml file not found! `treebeard setup` fetches an example.",
+            fg="yellow",
         )
+        click.echo("Using defaults: notebooks: - '**/*.ipynb' output_dirs: - 'outputs'")
 
     notebook_files = treebeard_config.get_deglobbed_notebooks()
     if not notebook_files:

--- a/treebeard-lib/treebeard/conf.py
+++ b/treebeard-lib/treebeard/conf.py
@@ -44,6 +44,8 @@ class TreebeardConfig(BaseModel):
         deglobbed_notebooks = []
         for pattern in self.notebooks:
             deglobbed_notebooks.extend(sorted(glob(pattern, recursive=True)))
+        if len(deglobbed_notebooks) == 0:
+            raise Exception("No notebooks found in project! (**/*.ipynb)")
         return deglobbed_notebooks
 
 


### PR DESCRIPTION
TreebeardConfig base class gets defaults for notebook glob pattern
No notebooks gives an error
No treebeard.yaml now gives a warning and defaults are used.

This should allow smooth working if the Github App is used on a repo that does not have a treebeard.yaml file

We might want to suggest adding a treebeard.yaml file somewhere else (if they are only getting notified through Github). e.g. the admin page.